### PR TITLE
Fix/v4.1.1.compiler errors

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-amb.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-amb.hpp
@@ -99,8 +99,7 @@ struct amb
         typedef Subscriber output_type;
 
         struct amb_state_type
-            : public std::enable_shared_from_this<amb_state_type>
-            , public values
+            : public values
         {
             amb_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -202,8 +202,7 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
         typedef Subscriber output_type;
 
         struct combine_latest_state_type
-            : public std::enable_shared_from_this<combine_latest_state_type>
-            , public values
+            : public values
         {
             combine_latest_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(std::move(i))

--- a/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-combine_latest.hpp
@@ -167,9 +167,7 @@ struct combine_latest : public operator_base<rxu::value_type_t<combine_latest_tr
                 value.reset(st);
 
                 if (state->valuesSet == sizeof... (ObservableN)) {
-                    auto values = rxu::surely(state->latest);
-                    auto selectedResult = rxu::apply(values, state->selector);
-                    state->out.on_next(selectedResult);
+                    state->out.on_next(rxu::apply(rxu::surely(state->latest), state->selector));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-concat_map.hpp
@@ -111,6 +111,8 @@ struct concat_map
             , coordination(std::move(sf))
         {
         }
+        values(values const& o) = default;
+        values(values&& o) = default;
         source_type source;
         collection_selector_type selectCollection;
         result_selector_type selectResult;
@@ -124,6 +126,9 @@ struct concat_map
         : initial(std::move(o), std::move(s), std::move(rs), std::move(sf))
     {
     }
+
+    concat_map(concat_map const& o) = default;
+    concat_map(concat_map&& o) = default;
 
     template<class Subscriber>
     void on_subscribe(Subscriber scbr) const {

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -128,8 +128,7 @@ struct flat_map
         typedef Subscriber output_type;
 
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(values i, coordinator_type coor, output_type oarg)
                 : values(std::move(i))

--- a/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-flat_map.hpp
@@ -194,8 +194,7 @@ struct flat_map
                     innercs,
                 // on_next
                     [state, st](collection_value_type ct) {
-                        auto selectedResult = state->selectResult(st, std::move(ct));
-                        state->out.on_next(std::move(selectedResult));
+                        state->out.on_next(state->selectResult(st, std::move(ct)));
                     },
                 // on_error
                     [state](rxu::error_ptr e) {

--- a/Rx/v2/src/rxcpp/operators/rx-merge.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge.hpp
@@ -103,8 +103,7 @@ struct merge
         typedef Subscriber output_type;
 
         struct merge_state_type
-            : public std::enable_shared_from_this<merge_state_type>
-            , public values
+            : public values
         {
             merge_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge_delay_error.hpp
@@ -96,8 +96,7 @@ struct merge_delay_error
                 typedef Subscriber output_type;
 
                 struct merge_state_type
-                        : public std::enable_shared_from_this<merge_state_type>
-                        , public values
+                        : public values
                 {
                         merge_state_type(values i, coordinator_type coor, output_type oarg)
                                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-multicast.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-multicast.hpp
@@ -38,7 +38,7 @@ struct multicast : public operator_base<T>
     typedef rxu::decay_t<Observable> source_type;
     typedef rxu::decay_t<Subject> subject_type;
 
-    struct multicast_state : public std::enable_shared_from_this<multicast_state>
+    struct multicast_state
     {
         multicast_state(source_type o, subject_type sub)
             : source(std::move(o))

--- a/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-reduce.hpp
@@ -141,7 +141,6 @@ struct reduce : public operator_base<rxu::value_type_t<reduce_traits<T, Observab
     void on_subscribe(Subscriber o) const {
         struct reduce_state_type
             : public reduce_initial_type
-            , public std::enable_shared_from_this<reduce_state_type>
         {
             reduce_state_type(reduce_initial_type i, Subscriber scrbr)
                 : reduce_initial_type(i)

--- a/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-ref_count.hpp
@@ -93,8 +93,7 @@ struct ref_count : public operator_base<T>
     // removed constexpr to support older VC compilers
     static /*constexpr */ const bool has_observable_v = has_observable_t::value;
 
-    struct ref_count_state : public std::enable_shared_from_this<ref_count_state>,
-                             public ref_count_state_base<ConnectableObservable, Observable>
+    struct ref_count_state : public ref_count_state_base<ConnectableObservable, Observable>
     {
         template <class HasObservable = has_observable_t,
                   class Enabled = rxu::enable_if_all_true_type_t<

--- a/Rx/v2/src/rxcpp/operators/rx-scan.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-scan.hpp
@@ -70,7 +70,6 @@ struct scan : public operator_base<rxu::decay_t<Seed>>
     void on_subscribe(Subscriber o) const {
         struct scan_state_type
             : public scan_initial_type
-            , public std::enable_shared_from_this<scan_state_type>
         {
             scan_state_type(scan_initial_type i, Subscriber scrbr)
                 : scan_initial_type(i)

--- a/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-sequence_equal.hpp
@@ -81,8 +81,7 @@ struct sequence_equal : public operator_base<bool>
         typedef Subscriber output_type;
 
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& vals, coordinator_type coor, const output_type& o)
                 : values(vals)

--- a/Rx/v2/src/rxcpp/operators/rx-skip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip.hpp
@@ -76,8 +76,7 @@ struct skip : public operator_base<T>
 
         typedef Subscriber output_type;
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& i, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_last.hpp
@@ -69,8 +69,7 @@ struct skip_last : public operator_base<T>
 
         typedef Subscriber output_type;
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& i, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-skip_until.hpp
@@ -87,8 +87,7 @@ struct skip_until : public operator_base<T>
 
         typedef Subscriber output_type;
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& i, coordinator_type coor, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-subscribe_on.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-subscribe_on.hpp
@@ -77,8 +77,7 @@ struct subscribe_on : public operator_base<T>
 
         typedef Subscriber output_type;
         struct subscribe_on_state_type
-            : public std::enable_shared_from_this<subscribe_on_state_type>
-            , public subscribe_on_values
+            : public subscribe_on_values
         {
             subscribe_on_state_type(const subscribe_on_values& i, const output_type& oarg)
                 : subscribe_on_values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-switch_on_next.hpp
@@ -82,8 +82,7 @@ struct switch_on_next
         typedef Subscriber output_type;
 
         struct switch_state_type
-            : public std::enable_shared_from_this<switch_state_type>
-            , public values
+            : public values
         {
             switch_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-take.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take.hpp
@@ -75,8 +75,7 @@ struct take : public operator_base<T>
 
         typedef Subscriber output_type;
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& i, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_last.hpp
@@ -69,8 +69,7 @@ struct take_last : public operator_base<T>
 
         typedef Subscriber output_type;
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(const values& i, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-take_until.hpp
@@ -97,8 +97,7 @@ struct take_until : public operator_base<T>
 
         typedef Subscriber output_type;
         struct take_until_state_type
-            : public std::enable_shared_from_this<take_until_state_type>
-            , public values
+            : public values
         {
             take_until_state_type(const values& i, coordinator_type coor, const output_type& oarg)
                 : values(i)

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -202,8 +202,7 @@ struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_fro
         typedef Subscriber output_type;
 
         struct with_latest_from_state_type
-            : public std::enable_shared_from_this<with_latest_from_state_type>
-            , public values
+            : public values
         {
             with_latest_from_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(std::move(i))

--- a/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-with_latest_from.hpp
@@ -167,9 +167,7 @@ struct with_latest_from : public operator_base<rxu::value_type_t<with_latest_fro
                 value.reset(st);
 
                 if (state->valuesSet == sizeof... (ObservableN) && Index == 0) {
-                    auto values = rxu::surely(state->latest);
-                    auto selectedResult = rxu::apply(values, state->selector);
-                    state->out.on_next(selectedResult);
+                    state->out.on_next(rxu::apply(rxu::surely(state->latest), state->selector));
                 }
             },
         // on_error

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -195,8 +195,8 @@ struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Sel
                 auto& values = std::get<Index>(state->pending).values;
                 values.push_back(st);
                 if (rxu::apply_to_each(state->pending, values_not_empty(), rxu::all_values_true())) {
-                    auto selectedResult = rxu::apply_to_each(state->pending, extract_value_front(), state->selector);
-                    state->out.on_next(selectedResult);
+
+                    state->out.on_next(rxu::apply_to_each(state->pending, extract_value_front(), state->selector));
                 }
                 if (rxu::apply_to_each(state->pending, source_completed_values_empty(), rxu::any_value_true())) {
                     state->out.on_completed();

--- a/Rx/v2/src/rxcpp/operators/rx-zip.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-zip.hpp
@@ -236,8 +236,7 @@ struct zip : public operator_base<rxu::value_type_t<zip_traits<Coordination, Sel
         typedef Subscriber output_type;
 
         struct zip_state_type
-            : public std::enable_shared_from_this<zip_state_type>
-            , public values
+            : public values
         {
             zip_state_type(values i, coordinator_type coor, output_type oarg)
                 : values(std::move(i))

--- a/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-connectable_observable.hpp
@@ -31,7 +31,6 @@ class dynamic_connectable_observable
     : public dynamic_observable<T>
 {
     struct state_type
-        : public std::enable_shared_from_this<state_type>
     {
         typedef std::function<void(composite_subscription)> onconnect_type;
 

--- a/Rx/v2/src/rxcpp/rx-coroutine.hpp
+++ b/Rx/v2/src/rxcpp/rx-coroutine.hpp
@@ -69,9 +69,13 @@ struct co_observable_inc_awaiter
 };
 
 template<typename Source>
-struct co_observable_iterator : public iterator<input_iterator_tag, typename Source::value_type>
+struct co_observable_iterator
 {
+    using iterator_category = input_iterator_tag;
+    using difference_type   = std::ptrdiff_t;
     using value_type = typename Source::value_type;
+    using pointer = value_type*;
+    using reference = value_type&;
 
     co_observable_iterator() {}
 

--- a/Rx/v2/src/rxcpp/rx-coroutine.hpp
+++ b/Rx/v2/src/rxcpp/rx-coroutine.hpp
@@ -34,7 +34,7 @@ template<typename Source>
 struct co_observable_iterator;
 
 template<typename Source>
-struct co_observable_iterator_state : std::enable_shared_from_this<co_observable_iterator_state<Source>>
+struct co_observable_iterator_state
 {
     using value_type = typename Source::value_type;
 

--- a/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-grouped_observable.hpp
@@ -36,7 +36,6 @@ public:
 
 private:
     struct state_type
-        : public std::enable_shared_from_this<state_type>
     {
         typedef std::function<key_type()> ongetkey_type;
 

--- a/Rx/v2/src/rxcpp/rx-notification.hpp
+++ b/Rx/v2/src/rxcpp/rx-notification.hpp
@@ -44,7 +44,6 @@ namespace detail {
 
 template<typename T>
 struct notification_base
-    : public std::enable_shared_from_this<notification_base<T>>
 {
     typedef subscriber<T> observer_type;
     typedef std::shared_ptr<notification_base<T>> type;

--- a/Rx/v2/src/rxcpp/rx-observable.hpp
+++ b/Rx/v2/src/rxcpp/rx-observable.hpp
@@ -37,7 +37,6 @@ class dynamic_observable
     : public rxs::source_base<T>
 {
     struct state_type
-        : public std::enable_shared_from_this<state_type>
     {
         typedef std::function<void(subscriber<T>)> onsubscribe_type;
 

--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -347,7 +347,7 @@ namespace detail
 {
 
 template<class T>
-struct virtual_observer : public std::enable_shared_from_this<virtual_observer<T>>
+struct virtual_observer
 {
     virtual ~virtual_observer() {}
     virtual void on_next(T&) const {};

--- a/Rx/v2/src/rxcpp/rx-scheduler.hpp
+++ b/Rx/v2/src/rxcpp/rx-scheduler.hpp
@@ -161,7 +161,6 @@ struct worker_base : public subscription_base
 };
 
 class worker_interface
-    : public std::enable_shared_from_this<worker_interface>
 {
     typedef worker_interface this_type;
 
@@ -652,7 +651,6 @@ struct current_thread;
 namespace detail {
 
 class action_type
-    : public std::enable_shared_from_this<action_type>
 {
     typedef action_type this_type;
 
@@ -681,7 +679,6 @@ public:
 };
 
 class action_tailrecurser
-    : public std::enable_shared_from_this<action_type>
 {
     typedef action_type this_type;
 

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -66,7 +66,7 @@ public:
 
 class subscription : public subscription_base
 {
-    class base_subscription_state : public std::enable_shared_from_this<base_subscription_state>
+    class base_subscription_state
     {
         base_subscription_state();
     public:
@@ -243,7 +243,7 @@ class composite_subscription_inner
 {
 private:
     typedef subscription::weak_state_type weak_subscription;
-    struct composite_subscription_state : public std::enable_shared_from_this<composite_subscription_state>
+    struct composite_subscription_state
     {
         // invariant: cannot access this data without the lock held.
         std::set<subscription> subscriptions;

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -470,6 +470,8 @@ struct print_function
     OStream& os;
     Delimit delimit;
     print_function(OStream& os, Delimit d) : os(os), delimit(std::move(d)) {}
+    print_function(print_function const& o) = default;
+    print_function(print_function&& o) = default;
 
     template<class... TN>
     void operator()(const TN&... tn) const {
@@ -489,6 +491,8 @@ struct endline
 {
     OStream& os;
     endline(OStream& os) : os(os) {}
+    endline(endline const& o) = default;
+    endline(endline&& o) = default;
     void operator()() const {
         os << std::endl;
     }
@@ -502,6 +506,8 @@ struct insert_value
     OStream& os;
     ValueType value;
     insert_value(OStream& os, ValueType v) : os(os), value(std::move(v)) {}
+    insert_value(insert_value const& o) = default;
+    insert_value(insert_value&& o) = default;
     void operator()() const {
         os << value;
     }
@@ -515,6 +521,8 @@ struct insert_function
     OStream& os;
     Function call;
     insert_function(OStream& os, Function f) : os(os), call(std::move(f)) {}
+    insert_function(insert_function const& o) = default;
+    insert_function(insert_function&& o) = default;
     void operator()() const {
         call(os);
     }

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -721,8 +721,8 @@ namespace detail {
 
 template<class... T>
 inline auto surely(const std::tuple<T...>& tpl)
-    -> decltype(apply(tpl, detail::surely())) {
-    return      apply(tpl, detail::surely());
+    -> decltype(apply(tpl, detail::surely {})) {
+    return      apply(tpl, detail::surely {});
 }
 
 namespace detail {
@@ -733,7 +733,7 @@ class unwinder
 public:
     ~unwinder()
     {
-        if (!!function)
+        if (function)
         {
             RXCPP_TRY {
                 (*function)();

--- a/Rx/v2/src/rxcpp/rx-util.hpp
+++ b/Rx/v2/src/rxcpp/rx-util.hpp
@@ -721,8 +721,8 @@ namespace detail {
 
 template<class... T>
 inline auto surely(const std::tuple<T...>& tpl)
-    -> decltype(apply(tpl, detail::surely {})) {
-    return      apply(tpl, detail::surely {});
+    -> decltype(util::apply(tpl, detail::surely {})) {
+    return      util::apply(tpl, detail::surely {});
 }
 
 namespace detail {

--- a/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-newthread.hpp
@@ -28,7 +28,7 @@ private:
 
         new_worker(const this_type&);
 
-        struct new_worker_state : public std::enable_shared_from_this<new_worker_state>
+        struct new_worker_state
         {
             typedef detail::schedulable_queue<
                 typename clock_type::time_point> queue_item_time;

--- a/Rx/v2/src/rxcpp/schedulers/rx-virtualtime.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-virtualtime.hpp
@@ -14,7 +14,7 @@ namespace schedulers {
 namespace detail {
 
 template<class Absolute, class Relative>
-struct virtual_time_base : std::enable_shared_from_this<virtual_time_base<Absolute, Relative>>
+struct virtual_time_base
 {
 private:
     typedef virtual_time_base<Absolute, Relative> this_type;

--- a/Rx/v2/src/rxcpp/sources/rx-scope.hpp
+++ b/Rx/v2/src/rxcpp/sources/rx-scope.hpp
@@ -73,8 +73,7 @@ struct scope : public source_base<rxu::value_type_t<scope_traits<ResourceFactory
     void on_subscribe(Subscriber o) const {
 
         struct state_type
-            : public std::enable_shared_from_this<state_type>
-            , public values
+            : public values
         {
             state_type(values i, Subscriber o)
                 : values(i)

--- a/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-behavior.hpp
@@ -19,7 +19,7 @@ class behavior_observer : public detail::multicast_observer<T>
     typedef behavior_observer<T> this_type;
     typedef detail::multicast_observer<T> base_type;
 
-    class behavior_observer_state : public std::enable_shared_from_this<behavior_observer_state>
+    class behavior_observer_state
     {
         mutable std::mutex lock;
         mutable T value;

--- a/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-replaysubject.hpp
@@ -36,7 +36,7 @@ class replay_observer : public detail::multicast_observer<T>
     typedef typename traits::coordination_type coordination_type;
     typedef typename traits::coordinator_type coordinator_type;
 
-    class replay_observer_state : public std::enable_shared_from_this<replay_observer_state>
+    class replay_observer_state
     {
         mutable std::mutex lock;
         mutable std::list<T> values;

--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -31,7 +31,6 @@ class multicast_observer
     };
 
     struct state_type
-        : public std::enable_shared_from_this<state_type>
     {
         explicit state_type(composite_subscription cs)
             : current(mode::Casting)
@@ -45,7 +44,6 @@ class multicast_observer
     };
 
     struct completer_type
-        : public std::enable_shared_from_this<completer_type>
     {
         ~completer_type()
         {
@@ -78,7 +76,6 @@ class multicast_observer
 
     // this type prevents a circular ref between state and completer
     struct binder_type
-        : public std::enable_shared_from_this<binder_type>
     {
         explicit binder_type(composite_subscription cs)
             : state(std::make_shared<state_type>(cs))


### PR DESCRIPTION
Fixes to make the project buildable on up-to-date Xcode and Visual Studio and some small optimisations to allow move instead of copy and remove unnecessary enable_shared_from_this.